### PR TITLE
fix: プライベートリポジトリの checkout 失敗を composite action 化で解消

### DIFF
--- a/.github/workflows/release-dashboard.yml
+++ b/.github/workflows/release-dashboard.yml
@@ -17,7 +17,7 @@ on:
         required: false
         default: 'main'
         type: string
-  workflow_call:  # Callable from external repositories
+  workflow_call:  # Callable from external repositories (public callers only; private callers must use the composite action instead)
     inputs:
       develop_branch:
         description: 'Develop branch name (default: develop)'
@@ -45,7 +45,13 @@ jobs:
       (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
 
     steps:
-      - name: Checkout release-dashboard-action scripts
+      # NOTE: This checkout uses the caller's GITHUB_TOKEN. It only succeeds when
+      # the caller can read kyo-ago/release-dashboard-action (public callers, or
+      # private callers that supply a token with read access). Private callers
+      # should switch to the composite action (uses: kyo-ago/release-dashboard-action@<ref>)
+      # instead, which is fetched via the runner's action download path and
+      # respects the organization's "Actions can access this repository" setting.
+      - name: Checkout release-dashboard-action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: kyo-ago/release-dashboard-action
@@ -54,11 +60,7 @@ jobs:
           path: release-dashboard-action
 
       - name: Update Release Dashboard
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: ./release-dashboard-action
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const updateDashboard = require('./release-dashboard-action/.github/scripts/update-dashboard.js');
-            const developBranch = '${{ inputs.develop_branch }}' || 'develop';
-            const mainBranch = '${{ inputs.main_branch }}' || 'main';
-            await updateDashboard({ github, context, developBranch, mainBranch });
+          develop_branch: ${{ inputs.develop_branch || 'develop' }}
+          main_branch: ${{ inputs.main_branch || 'main' }}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Automatically tracks PRs merged into the develop branch but not yet released to 
 - Removes items automatically after release to the main branch
 - **Supports all merge methods: Squash, Rebase, and Merge commit**
 - **Automatic merge-back when using Squash merge**
-- Usable from external repositories as a reusable workflow
+- Usable from external repositories as a composite action (recommended) or as a reusable workflow
 - Supports custom branch names
 
 ## 🚀 Quick Start
@@ -28,22 +28,36 @@ on:
   push:
     branches:
       - develop
-  pull_request:
-    types: [closed]
-    branches:
-      - develop
+      - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
 jobs:
-  call-release-dashboard:
-    uses: kyo-ago/release-dashboard-action/.github/workflows/release-dashboard.yml@main
-    permissions:
-      contents: read
-      issues: write
-      pull-requests: read
+  update-dashboard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kyo-ago/release-dashboard-action@main
 ```
 
 Commit and push to finish.
+
+> **Note**
+> The composite action (`uses: kyo-ago/release-dashboard-action@<ref>`) is the
+> recommended invocation. The runner downloads it via the standard action
+> distribution path, which works for private callers as long as the
+> organization allows it under **Settings → Actions → General → Access**.
+>
+> A reusable-workflow form
+> (`uses: kyo-ago/release-dashboard-action/.github/workflows/release-dashboard.yml@<ref>`)
+> is still provided for backward compatibility, but it relies on
+> `actions/checkout` to pull this repository using the caller's `GITHUB_TOKEN`.
+> Private callers cannot read another private repository with `GITHUB_TOKEN`,
+> so the reusable-workflow form fails with `repository not found` for that
+> case. Use the composite action instead.
 
 ## 🎯 Usage
 
@@ -66,28 +80,30 @@ Runs automatically in the following cases:
 
 ```yaml
 jobs:
-  call-release-dashboard:
-    uses: kyo-ago/release-dashboard-action/.github/workflows/release-dashboard.yml@main
-    with:
-      develop_branch: 'staging'
-      main_branch: 'production'
+  update-dashboard:
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       issues: write
       pull-requests: read
+    steps:
+      - uses: kyo-ago/release-dashboard-action@main
+        with:
+          develop_branch: staging
+          main_branch: production
 ```
 
 ### Version Pinning
 
 ```yaml
 # Latest
-uses: kyo-ago/release-dashboard-action/.github/workflows/release-dashboard.yml@main
+- uses: kyo-ago/release-dashboard-action@main
 
 # Pin by tag
-uses: kyo-ago/release-dashboard-action/.github/workflows/release-dashboard.yml@v1.0.0
+- uses: kyo-ago/release-dashboard-action@v1.0.0
 
 # Pin by commit hash
-uses: kyo-ago/release-dashboard-action/.github/workflows/release-dashboard.yml@abc1234
+- uses: kyo-ago/release-dashboard-action@abc1234
 ```
 
 ## 🔄 Squash Merge Support

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,43 @@
+name: 'Release Dashboard'
+description: 'Track PRs merged into the develop branch but not yet released to main, and surface them in a dedicated dashboard issue.'
+author: 'kyo-ago'
+branding:
+  icon: 'git-pull-request'
+  color: 'blue'
+
+inputs:
+  develop_branch:
+    description: 'Develop branch name'
+    required: false
+    default: 'develop'
+  main_branch:
+    description: 'Main branch name'
+    required: false
+    default: 'main'
+  github_token:
+    description: 'Token used to read PRs/commits and write the dashboard issue (needs contents:read, issues:write, pull-requests:read).'
+    required: false
+    default: ${{ github.token }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Update Release Dashboard
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+      env:
+        RELEASE_DASHBOARD_DEVELOP_BRANCH: ${{ inputs.develop_branch }}
+        RELEASE_DASHBOARD_MAIN_BRANCH: ${{ inputs.main_branch }}
+        RELEASE_DASHBOARD_ACTION_PATH: ${{ github.action_path }}
+      with:
+        github-token: ${{ inputs.github_token }}
+        script: |
+          const path = require('path');
+          const updateDashboard = require(
+            path.join(process.env.RELEASE_DASHBOARD_ACTION_PATH, '.github/scripts/update-dashboard.js')
+          );
+          await updateDashboard({
+            github,
+            context,
+            developBranch: process.env.RELEASE_DASHBOARD_DEVELOP_BRANCH,
+            mainBranch: process.env.RELEASE_DASHBOARD_MAIN_BRANCH,
+          });


### PR DESCRIPTION
## 背景

reusable workflow (`.github/workflows/release-dashboard.yml`) を private リポジトリから `workflow_call` した際、内部の `actions/checkout` が `repository 'https://github.com/<org>/release-dashboard-action/' not found` で 3 回連続失敗するという報告。

呼び出し元の `GITHUB_TOKEN` のスコープは呼び出し元リポジトリに限定されるため、別の private リポジトリを read できないことが根本原因。reusable workflow の YAML 自体は organization 設定の Actions access 経由で取得されるが、その内部で `actions/checkout` が使う token は別物、というのが GitHub Actions の仕様。

## 対応 (方針 A: composite action 化)

- `action.yml` をリポジトリルートに新設し、composite action として配布する。
  - スクリプト本体は `${{ github.action_path }}/.github/scripts/update-dashboard.js` を `require` で読み込む。
  - `develop_branch` / `main_branch` / `github_token` を入力として受け付ける。
  - `actions/github-script` には pin 済み SHA (`v8.0.0`) で渡す。
- `.github/workflows/release-dashboard.yml` を整理し、自リポジトリで動かす push/workflow_dispatch ジョブも同 composite action 経由 (`uses: ./release-dashboard-action`) で実行されるようにした。
- `workflow_call` のエントリは public 呼び出し元の後方互換のために残置 (private 呼び出し元では従来通り checkout が失敗する点をコメントと README で明示)。
- README をアップデートし、composite action 記法を「推奨」、reusable workflow 記法を「後方互換用、private 呼び出し元では失敗する」と区別。

## 動作確認

- 本リポジトリ内には composite action のテストハーネスが無いため、コードレベルでの確認のみ:
  - `action.yml` の `runs.using: composite` 経路が `actions/github-script` に `process.env.RELEASE_DASHBOARD_*` を渡し、`require(path.join(action_path, '.github/scripts/update-dashboard.js'))` で既存ロジックを呼ぶ構造。
  - 既存の `update-dashboard.js` の interface (`{ github, context, developBranch, mainBranch }`) は変更なし。
- 実環境での疎通確認は aistudio 側の caller を composite action に切り替えた後に `Release Dashboard` workflow を `workflow_dispatch` で再実行して行う必要あり (下記参照)。

## 呼び出し元 (aistudio) で必要な追加対応

このリポジトリへの変更だけでは aistudio の失敗は直らない。aistudio 側で別 PR が必要:

```diff
 jobs:
   call-release-dashboard:
-    uses: <org>/release-dashboard-action/.github/workflows/release-dashboard.yml@<sha>
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      - uses: <org>/release-dashboard-action@<sha>
+        # with:
+        #   develop_branch: develop
+        #   main_branch: main
```

ポイント:

- `uses:` を job レベルの reusable workflow 参照から、step レベルの action 参照に変更する。
- 呼び出し元 job 側で `permissions` を明示する (reusable workflow の中で宣言していたのが効かなくなるため)。
- `<sha>` には本 PR が `develop` (もしくは `main`) に merge された後のコミット SHA、または release tag を指定する。
- organization 設定 (`Settings → Actions → General → Access`) で `kyo-ago/release-dashboard-action` への access が許可されている必要がある (許可済みなら追加作業なし)。

## 既知の残課題 (本 PR スコープ外)

- `.github/workflows/sync-branches.yml` も同じ checkout パターンを持つため、private 呼び出し元で `workflow_call` した場合に同じ失敗が起きる。利用実績次第で別 PR で同様に composite/action 化するのを推奨。

## チェックリスト

- [ ] aistudio 側 PR で composite action へ切り替え
- [ ] aistudio で `Release Dashboard` を `workflow_dispatch` 実行し全 step 成功を確認
- [ ] Release Dashboard Issue の PR 追加/削除が従来通り機能することを確認

https://claude.ai/code/session_017fyiuCayPvjm4p4mLvNaZQ
